### PR TITLE
Send shorter links to products images. Mailchimp rejects current ones…

### DIFF
--- a/app/presenters/product_mailchimp_presenter.rb
+++ b/app/presenters/product_mailchimp_presenter.rb
@@ -31,7 +31,7 @@ module SpreeMailchimpEcommerce
         image = product.images.first
         return "" unless image
 
-        Rails.application.routes.url_helpers.url_for(image.url(:product))
+        Rails.application.routes.url_helpers.rails_blob_url(image.attachment)
       end
     end
   end


### PR DESCRIPTION
… because of theirs length. This is only temporary solution because it uses not normalised original images.