### PR TITLE
Some Fixes

### DIFF
--- a/app/helpers/mailchimp_helper.rb
+++ b/app/helpers/mailchimp_helper.rb
@@ -1,7 +1,9 @@
-  module MailchimpHelper
+module MailchimpHelper
+
     def mailchimp_snippet
       set_snippet&.html_safe
     end
+
 
     private
 
@@ -17,4 +19,5 @@
     def mailchimp_store_id
       ::SpreeMailchimpEcommerce.configuration.mailchimp_store_id
     end
-  end
+
+end

--- a/app/jobs/spree_mailchimp_ecommerce/create_order_cart_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/create_order_cart_job.rb
@@ -5,7 +5,7 @@ module SpreeMailchimpEcommerce
     def perform(cart)
       gibbon_store.carts.create(body: cart)
     rescue Gibbon::MailChimpError => e
-      Rails.logger.warn "[MAILCHIMP] Failed to create cart #{e}"
+      Rails.logger.warn "[MAILCHIMP] Failed to create mailchimp cart #{e}"
     end
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/create_order_cart_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/create_order_cart_job.rb
@@ -4,6 +4,8 @@ module SpreeMailchimpEcommerce
   class CreateOrderCartJob < ApplicationJob
     def perform(cart)
       gibbon_store.carts.create(body: cart)
+    rescue Gibbon::MailChimpError => e
+      Rails.logger.warn "[MAILCHIMP] Failed to create cart #{e}"
     end
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/create_product_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/create_product_job.rb
@@ -7,8 +7,8 @@ module SpreeMailchimpEcommerce
       return unless product.mailchimp_product
 
       gibbon_store.products.create(body: product.mailchimp_product)
-    rescue Gibbon::MailChimpError => e
-      Rails.logger.warn "[MAILCHIMP] Failed to create a product with ID = #{product_id}. #{e}"
+      rescue Gibbon::MailChimpError => e
+        Rails.logger.warn "[MAILCHIMP] Failed to create a product with ID = #{product_id}. #{e}"
     end
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/create_user_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/create_user_job.rb
@@ -2,8 +2,13 @@
 
 module SpreeMailchimpEcommerce
   class CreateUserJob < ApplicationJob
+
     def perform(mailchimp_user)
       gibbon_store.customers.create(body: mailchimp_user)
+
+      rescue Gibbon::MailChimpError => e
+        Rails.logger.warn "[MAILCHIMP] Customer Already Exists. #{e}"
     end
+
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/create_user_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/create_user_job.rb
@@ -7,7 +7,7 @@ module SpreeMailchimpEcommerce
       gibbon_store.customers.create(body: mailchimp_user)
 
       rescue Gibbon::MailChimpError => e
-        Rails.logger.warn "[MAILCHIMP] Customer Already Exists. #{e}"
+        Rails.logger.warn "[MAILCHIMP] Failed to create mailchimp user. #{e}"
     end
 
   end

--- a/app/jobs/spree_mailchimp_ecommerce/delete_cart_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/delete_cart_job.rb
@@ -4,6 +4,10 @@ module SpreeMailchimpEcommerce
   class DeleteCartJob < ApplicationJob
     def perform(order_number)
       gibbon_store.carts(order_number).delete
+
+    rescue Gibbon::MailChimpError => e
+      Rails.logger.warn "[MAILCHIMP] Failed to delete mailchimp cart #{e}"
+
     end
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/delete_cart_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/delete_cart_job.rb
@@ -7,7 +7,7 @@ module SpreeMailchimpEcommerce
 
     rescue Gibbon::MailChimpError => e
       Rails.logger.warn "[MAILCHIMP] Failed to delete mailchimp cart #{e}"
-
     end
+    
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/delete_line_item_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/delete_line_item_job.rb
@@ -2,12 +2,10 @@
 
 module SpreeMailchimpEcommerce
   class DeleteLineItemJob < ApplicationJob
-    def perform(line_id)
-      line = ::Spree::LineItem.find(line_id)
 
-      gibbon_store.carts(line.order.number).lines(Digest::MD5.hexdigest("#{line.id}#{line.order_id}")).delete
-    rescue Gibbon::MailChimpError => e
-      Rails.logger.warn "[MAILCHIMP] Failed to delete line item = #{line.id}. #{e}"
+    def perform(cart_number, line_id)
+      gibbon_store.carts(cart_number).lines(line_id).delete
     end
+
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/update_order_cart_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/update_order_cart_job.rb
@@ -4,6 +4,9 @@ module SpreeMailchimpEcommerce
   class UpdateOrderCartJob < ApplicationJob
     def perform(mailchimp_cart)
       gibbon_store.carts(mailchimp_cart["id"]).update(body: mailchimp_cart)
+      rescue Gibbon::MailChimpError => e
+        Rails.logger.warn "[MAILCHIMP] No Order To Update #{e}"
+
     end
   end
 end

--- a/app/jobs/spree_mailchimp_ecommerce/update_order_cart_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/update_order_cart_job.rb
@@ -5,7 +5,7 @@ module SpreeMailchimpEcommerce
     def perform(mailchimp_cart)
       gibbon_store.carts(mailchimp_cart["id"]).update(body: mailchimp_cart)
       rescue Gibbon::MailChimpError => e
-        Rails.logger.warn "[MAILCHIMP] No Order To Update #{e}"
+        Rails.logger.warn "[MAILCHIMP] Failed to update mailchimp cart. #{e}"
 
     end
   end

--- a/app/jobs/spree_mailchimp_ecommerce/update_product_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/update_product_job.rb
@@ -10,3 +10,4 @@ module SpreeMailchimpEcommerce
     end
   end
 end
+ 

--- a/app/models/spree/image_decorator.rb
+++ b/app/models/spree/image_decorator.rb
@@ -1,6 +1,7 @@
 module Spree
   module SpreeMailchimpEcommerce
     module ImageDecorator
+
       def self.prepended(base)
         base.after_create :update_mailchimp_product
         base.after_update :update_mailchimp_product

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -9,6 +9,12 @@ module Spree
         end
       end
 
+      def mailchimp_line_item
+        ::SpreeMailchimpEcommerce::Presenters::LineMailchimpPresenter.new(self).json
+      end
+
+      private
+
       def handle_cart
         return unless order.user
 
@@ -19,14 +25,8 @@ module Spree
         end
       end
 
-      def mailchimp_line_item
-        ::SpreeMailchimpEcommerce::Presenters::LineMailchimpPresenter.new(self).json
-      end
-
-      private
-
       def delete_line_item(order_number, deleted_line_item_id, deletedline_item_order_id)
-        return unless order.user
+        return unless order.user || !order.mailchimp_cart_created
 
         if order.checkout_allowed?
           associated_order = order_number

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -27,7 +27,7 @@ module Spree
 
       def delete_line_item(order_number, deleted_line_item_id, deletedline_item_order_id)
         return unless order.user
-        
+
         if order.checkout_allowed?
           associated_order = order_number
           line_id = Digest::MD5.hexdigest("#{deleted_line_item_id}#{deletedline_item_order_id}")

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -26,7 +26,7 @@ module Spree
       end
 
       def delete_line_item(order_number, deleted_line_item_id, deletedline_item_order_id)
-        return unless order.user || !order.mailchimp_cart_created
+        return unless order.user && order.mailchimp_cart_created
 
         if order.checkout_allowed?
           associated_order = order_number

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -25,6 +25,8 @@ module Spree
         return if mailchimp_cart_created
 
         ::SpreeMailchimpEcommerce::CreateOrderCartJob.perform_later(mailchimp_cart)
+
+        #ToDo update_coloumn should be triggered from sucess response from API, here we are assuming cart was created.
         update_column(:mailchimp_cart_created, true)
       end
 
@@ -33,9 +35,11 @@ module Spree
       end
 
       def delete_mailchimp_cart
-        return unless mailchimp_cart_created
-
+        #ToDo Try Fix Failing Spec but this should be correct, no point deleteing a cart that didnt get created -> return unless mailchimp_cart_created
         ::SpreeMailchimpEcommerce::DeleteCartJob.perform_later(number)
+
+
+        #ToDo update_coloumn should be triggered from sucess response from API, here we are assuming cart was delteted.
         update_column(:mailchimp_cart_created, nil)
       end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -25,21 +25,19 @@ module Spree
         return if mailchimp_cart_created
 
         ::SpreeMailchimpEcommerce::CreateOrderCartJob.perform_later(mailchimp_cart)
-
-        #ToDo update_coloumn should be triggered from sucess response from API, here we are assuming cart was created.
         update_column(:mailchimp_cart_created, true)
       end
 
       def update_mailchimp_cart
+        return unless mailchimp_cart_created
+
         ::SpreeMailchimpEcommerce::UpdateOrderCartJob.perform_later(mailchimp_cart)
       end
 
       def delete_mailchimp_cart
-        #ToDo Try Fix Failing Spec but this should be correct, no point deleteing a cart that didnt get created -> return unless mailchimp_cart_created
+        return unless mailchimp_cart_created
+
         ::SpreeMailchimpEcommerce::DeleteCartJob.perform_later(number)
-
-
-        #ToDo update_coloumn should be triggered from sucess response from API, here we are assuming cart was delteted.
         update_column(:mailchimp_cart_created, nil)
       end
 

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -13,8 +13,8 @@ module Spree
       end
 
       def mailchimp_image_url
-  # Works For ActiveStorage
-        images.first&.attachment
+        images.first&.attachment&.url || ""
+        # Works For ActiveStorage -> images.first&.attachment
       end
 
       private

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -13,8 +13,7 @@ module Spree
       end
 
       def mailchimp_image_url
-        images.first&.attachment&.url || ""
-        # Works For ActiveStorage -> images.first&.attachment images.first&.attachment&.send(image_method)
+        images.first&.attachment&.send(image_method)
       end
 
       private

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,7 @@
 module Spree
   module SpreeMailchimpEcommerce
     module ProductDecorator
+
       def self.prepended(base)
         base.after_create :create_mailchimp_product
         base.after_update :update_mailchimp_product
@@ -12,7 +13,8 @@ module Spree
       end
 
       def mailchimp_image_url
-        images.first&.attachment&.url || ""
+  # Works For ActiveStorage
+        images.first&.attachment
       end
 
       private

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -11,7 +11,7 @@ module Spree
       end
 
       def mailchimp_subscriber
-          ::SpreeMailchimpEcommerce::Presenters::SubscriberMailchimpPresenter.new(self).json
+        ::SpreeMailchimpEcommerce::Presenters::SubscriberMailchimpPresenter.new(self).json
       end
 
       private

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -11,7 +11,7 @@ module Spree
       end
 
       def mailchimp_subscriber
-        ::SpreeMailchimpEcommerce::Presenters::SubscriberMailchimpPresenter.new(self).json
+          ::SpreeMailchimpEcommerce::Presenters::SubscriberMailchimpPresenter.new(self).json
       end
 
       private

--- a/app/presenters/product_mailchimp_presenter.rb
+++ b/app/presenters/product_mailchimp_presenter.rb
@@ -28,8 +28,9 @@ module SpreeMailchimpEcommerce
       end
 
       def image_url
-  # Works For ActiveStorage
-        Rails.application.routes.url_helpers.url_for(product.mailchimp_image_url)
+  
+        product.mailchimp_image_url
+        # Works For ActiveStorage -> Rails.application.routes.url_helpers.url_for(product.mailchimp_image_url)
       end
     end
   end

--- a/app/presenters/product_mailchimp_presenter.rb
+++ b/app/presenters/product_mailchimp_presenter.rb
@@ -28,7 +28,8 @@ module SpreeMailchimpEcommerce
       end
 
       def image_url
-        product.mailchimp_image_url
+  # Works For ActiveStorage
+        Rails.application.routes.url_helpers.url_for(product.mailchimp_image_url)
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -35,7 +35,7 @@ describe Spree::Order, type: :model do
 
   describe "mailchimp" do
     describe "order" do
-      subject { build(:order) }
+      subject { build(:order, mailchimp_cart_created: true) }
       it "schedules mailchimp notification on order complete" do
         subject.state = "payment"
         subject.save!
@@ -46,4 +46,3 @@ describe Spree::Order, type: :model do
     end
   end
 end
-


### PR DESCRIPTION
- Fixed delete Mailchimp line item job. #44 (tested in live store, deletes the correct line item, as yet no Rspec test is written).
- Stopped delete Mailchimp line item job being called if order has no user or no mailchimp_cart is active.
- Now deletes Mailchimp cart if the customer empties cart avoiding empty abandoned cart email from being sent. #43
