### PR TITLE
Typo: tablename not plural

### DIFF
--- a/db/migrate/20190917095127_add_state_to_settings.rb
+++ b/db/migrate/20190917095127_add_state_to_settings.rb
@@ -1,5 +1,5 @@
 class AddStateToSettings < SpreeExtension::Migration[4.2]
   def change
-    add_column :mailchimp_setting, :state, :string, default: 'inactive'
+    add_column :mailchimp_settings, :state, :string, default: 'inactive'
   end
 end


### PR DESCRIPTION
Table mailchimp_setting does not exists. 

Pluralize table name from  mailchimp_setting to  mailchimp_settings.