### PR TITLE
return empty string on gibbon error

### DIFF
--- a/lib/mailchimp_helper.rb
+++ b/lib/mailchimp_helper.rb
@@ -15,6 +15,7 @@ module MailchimpHelper
             ecommerce.stores(mailchimp_store_id).retrieve.body["connected_site"]["site_script"]["fragment"]
         end
       rescue Gibbon::MailChimpError => e
+        Rails.logger.error("[MAILCHIMP] error on retrieving snippet #{e}")
         ""
       end
     end

--- a/lib/mailchimp_helper.rb
+++ b/lib/mailchimp_helper.rb
@@ -9,9 +9,13 @@ module MailchimpHelper
     def set_snippet
       return unless mailchimp_store_id && ::SpreeMailchimpEcommerce.configuration.mailchimp_api_key
 
-      Rails.cache.fetch "mailchimp_settings_#{mailchimp_store_id}" do
-        ::Gibbon::Request.new(api_key: ::SpreeMailchimpEcommerce.configuration.mailchimp_api_key).
-          ecommerce.stores(mailchimp_store_id).retrieve.body["connected_site"]["site_script"]["fragment"]
+      begin
+        Rails.cache.fetch "mailchimp_settings_#{mailchimp_store_id}" do
+          ::Gibbon::Request.new(api_key: ::SpreeMailchimpEcommerce.configuration.mailchimp_api_key).
+            ecommerce.stores(mailchimp_store_id).retrieve.body["connected_site"]["site_script"]["fragment"]
+        end
+      rescue Gibbon::MailChimpError => e
+        ""
       end
     end
 


### PR DESCRIPTION
In case when store deleted on mailchimp side, this part of code return GibbonError and crash whole application. This request fix it.