### PR TITLE
Base timezones in UTC

### DIFF
--- a/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
@@ -14,7 +14,7 @@ module SpreeMailchimpEcommerce
     def json
       order_json.merge(campaign_id).merge(promotions).merge(
         {
-          processed_at_foreign: order.completed_at.strftime("%Y%m%dT%H%M%S"),
+          processed_at_foreign: order.completed_at.in_time_zone("UTC").iso8601,
           discount_total: - order.promo_total || 0.0,
           tax_total: order.additional_tax_total || 0.0,
           shipping_total: order.shipment_total || 0.0,

--- a/app/presenters/spree_mailchimp_ecommerce/promo_code_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/promo_code_mailchimp_presenter.rb
@@ -15,8 +15,8 @@ module SpreeMailchimpEcommerce
         code: promotion.code || "",
         redemption_url: redemption_url,
         usage_count: promotion.credits_count,
-        created_at_foreign: promotion.created_at.strftime("%Y%m%dT%H%M%S") || "",
-        updated_at_foreign: promotion.updated_at.strftime("%Y%m%dT%H%M%S") || ""
+        created_at_foreign: promotion.created_at.in_time_zone("UTC").iso8601 || "",
+        updated_at_foreign: promotion.updated_at.in_time_zone("UTC").iso8601 || ""
       }.as_json
     end
 

--- a/app/presenters/spree_mailchimp_ecommerce/promo_rule_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/promo_rule_mailchimp_presenter.rb
@@ -21,20 +21,20 @@ module SpreeMailchimpEcommerce
         amount: amount.to_f,
         type: type || "fixed",
         target: target || "total",
-        created_at_foreign: promotion.created_at.strftime("%Y%m%dT%H%M%S"),
-        updated_at_foreign: promotion.updated_at.strftime("%Y%m%dT%H%M%S")
+        created_at_foreign: promotion.created_at.in_time_zone("UTC").iso8601,
+        updated_at_foreign: promotion.updated_at.in_time_zone("UTC").iso8601
       }.as_json
     end
 
     private
 
     def starts_at
-      promotion.starts_at ? promotion.starts_at.strftime("%Y%m%dT%H%M%S") : ""
+      promotion.starts_at ? promotion.starts_at.in_time_zone("UTC").iso8601 : ""
     end
 
     # with ends_at as "" the promo_code is unavaialbe but still exist
     def ends_at
-      available? && promotion.expires_at ? promotion.expires_at.strftime("%Y%m%dT%H%M%S") : ""
+      available? && promotion.expires_at ? promotion.expires_at.in_time_zone("UTC").iso8601 : ""
     end
 
     def amount


### PR DESCRIPTION
After installing this gem on my site, I noticed that the timing of orders was off on mailchimp's UI.  I discovered that even if you annotate your timezone, Mailchimp assumes the times you send in iso8601 format are in UTC.  Casting all times to UTC (since `completed_at` etc. use locally time-zoned times) and then using the `iso8601` helper simplified this code and results in the correct time appearing in the mailchimp console.