### PR TITLE
Promo Code can't be nil

### DIFF
--- a/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
@@ -39,7 +39,7 @@ module SpreeMailchimpEcommerce
       promos = promotions_list.map do |p|
         rule = PromoRuleMailchimpPresenter.new(p).json
         {
-          code: p.code,
+          code: p.code || "",
           amount_discounted: rule['amount'],
           type: rule['type']
         }


### PR DESCRIPTION
Was getting lots of the following error when synching my store... turns
out the code can be nil in Spree, so needs to be represented as "" here,
as is done in `PromoCodeMailchimpPresenter`.

```[MAILCHIMP] Error while creating order: the server responded with status 400 @title="Invalid Resource", @detail="The resource submitted could not be validated. For field-specific details, see the 'errors' array.", @body={"type"=>"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/", "title"=>"Invalid Resource", "status"=>400, "detail"=>"The resource submitted could not be validated. For field-specific details, see the 'errors' array.", "instance"=>"86bc0384-400b-447e-96ef-714f9daa7e63", "errors"=>[{"field"=>"promos.item:0", "message"=>"Required fields were not provided: code"}, {"field"=>"promos.item:0.code", "message"=>"Schema describes string, NULL found instead"}]}, @raw_body="{\"type\":\"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/\",\"title\":\"Invalid Resource\",\"status\":400,\"detail\":\"The resource submitted could not be validated. For field-specific details, see the 'errors' array.\",\"instance\":\"86bc0384-400b-447e-96ef-714f9daa7e63\",\"errors\":[{\"field\":\"promos.item:0\",\"message\":\"Required fields were not provided: code\"},{\"field\":\"promos.item:0.code\",\"message\":\"Schema describes string, NULL found instead\"}]}", @status_code=400```