### PR TITLE
Use dig to prevent NoMethodError execptions

### DIFF
--- a/lib/mailchimp_helper.rb
+++ b/lib/mailchimp_helper.rb
@@ -12,7 +12,7 @@ module MailchimpHelper
       begin
         Rails.cache.fetch "mailchimp_settings_#{mailchimp_store_id}" do
           ::Gibbon::Request.new(api_key: ::SpreeMailchimpEcommerce.configuration.mailchimp_api_key).
-            ecommerce.stores(mailchimp_store_id).retrieve.body["connected_site"]["site_script"]["fragment"]
+            ecommerce.stores(mailchimp_store_id).retrieve.body.dig "connected_site", "site_script", "fragment"
         end
       rescue Gibbon::MailChimpError => e
         Rails.logger.error("[MAILCHIMP] error on retrieving snippet #{e}")


### PR DESCRIPTION
While my store was going the initial sync, for some reason the Mailchimp
API was returning json that did not have the `connected_site` key.  This
resulted in the helper blowing up with `NoMethodError` when trying to
get the `site_script` from the `nil` `connected_site` value from `body`.

Using `#dig` will be a safer alternative and still returns nil if
nothing is found.

P.S. this took down my website, every page during initial sync.