### PR TITLE
Fix nil error in order.mailchimp_cart

### DIFF
--- a/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
@@ -48,7 +48,7 @@ module SpreeMailchimpEcommerce
     end
 
     def promotions_list
-      order.all_adjustments.eligible.nonzero.promotion.map(&:source).map(&:promotion).uniq
+      order.all_adjustments.eligible.nonzero.promotion.map(&:source).compact.map(&:promotion).uniq
     end
 
     def user


### PR DESCRIPTION
In my historical dataset of spree orders, there are some promotion
actions that don't actually have a source.  The first `map` in this line
can return `[nil]` if the only adjustment/promotion (for whatever
reason) doesn't have a source.  In these cases, the `&:promotion` in the
second map will fail.  To fix, just `compact` out the nil sources.