### PR TITLE
Fix delete line item job

### DIFF
--- a/app/jobs/spree_mailchimp_ecommerce/delete_line_item_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/delete_line_item_job.rb
@@ -3,9 +3,9 @@
 module SpreeMailchimpEcommerce
   class DeleteLineItemJob < ApplicationJob
     def perform(line_id, order_id, order_number)
-      gibbon_store.carts(line.order.number).lines(Digest::MD5.hexdigest("#{line.id}#{line.order_id}")).delete
+      gibbon_store.carts(order_number).lines(Digest::MD5.hexdigest("#{line_id}#{order_id}")).delete
     rescue Gibbon::MailChimpError => e
-      Rails.logger.warn "[MAILCHIMP] Failed to delete line item = #{line.id}. #{e}"
+      Rails.logger.warn "[MAILCHIMP] Failed to delete line item = #{line_id}. #{e}"
     end
   end
 end


### PR DESCRIPTION
This job was using the `line` variable which is undefined and potentially unavailable (as the Line Item is likely already deleted from the DB).  Just rely on the params passed into the job.