### PR TITLE
Don't fail when attempting to delete missing cart

### DIFF
--- a/app/jobs/spree_mailchimp_ecommerce/delete_cart_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/delete_cart_job.rb
@@ -3,7 +3,12 @@
 module SpreeMailchimpEcommerce
   class DeleteCartJob < ApplicationJob
     def perform(order_number)
-      gibbon_store.carts(order_number).delete
+      begin
+        gibbon_store.carts(order_number).delete
+      rescue Gibbon::MailChimpError => e
+        # silently eat the exception if we're trying to delete a cart that doesn't exist
+        raise unless e.body["status"] == 404
+      end
     end
   end
 end


### PR DESCRIPTION
If attempting to delete a cart results in error that means the cart is gone, so eat the exception.