### PR TITLE
fix codeless promos

### DIFF
--- a/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/order_mailchimp_presenter.rb
@@ -39,7 +39,7 @@ module SpreeMailchimpEcommerce
       promos = promotions_list.map do |p|
         rule = PromoRuleMailchimpPresenter.new(p).json
         {
-          code: p.code || "",
+          code: p.code || "promotion:#{p.id}",
           amount_discounted: rule['amount'],
           type: rule['type']
         }

--- a/app/presenters/spree_mailchimp_ecommerce/promo_code_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/promo_code_mailchimp_presenter.rb
@@ -12,7 +12,7 @@ module SpreeMailchimpEcommerce
     def json
       {
         id: Digest::MD5.hexdigest(promotion.id.to_s),
-        code: promotion.code || "",
+        code: promotion.code || "promotion:#{promotion.id}",
         redemption_url: redemption_url,
         usage_count: promotion.credits_count,
         created_at_foreign: promotion.created_at.in_time_zone("UTC").iso8601 || "",


### PR DESCRIPTION
In spree, it's valid to have a promotion without a code (e.g. automatic
free shipping promos often have this).  In mailchimp, a promo cannot
have an empty string as a code which is what was defaulted to in the
promotion presenters.  Instead, default to a placeholder string:
`"promotion:#{promotion.id}"`.