### PR TITLE
UpdateOrderJob -> UpsertOrderJob

### DIFF
--- a/app/jobs/spree_mailchimp_ecommerce/update_order_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/update_order_job.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module SpreeMailchimpEcommerce
-  class UpdateOrderJob < ApplicationJob
-    def perform(mailchimp_order)
-      gibbon_store.orders(mailchimp_order["id"]).update(body: mailchimp_order)
-    end
-  end
-end

--- a/app/jobs/spree_mailchimp_ecommerce/upsert_order_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/upsert_order_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SpreeMailchimpEcommerce
+  class UpsertOrderJob < ApplicationJob
+    def perform(mailchimp_order)
+      gibbon_store.orders(mailchimp_order["id"]).upsert(body: mailchimp_order)
+    end
+  end
+end

--- a/app/models/spree_mailchimp_ecommerce/spree/order_decorator.rb
+++ b/app/models/spree_mailchimp_ecommerce/spree/order_decorator.rb
@@ -64,7 +64,7 @@ module SpreeMailchimpEcommerce
       end
 
       def update_mailchimp_order
-        ::SpreeMailchimpEcommerce::UpdateOrderJob.perform_later(mailchimp_order)
+        ::SpreeMailchimpEcommerce::UpsertOrderJob.perform_later(mailchimp_order)
       end
 
       def new_order_notification

--- a/spec/features/order_notification_spec.rb
+++ b/spec/features/order_notification_spec.rb
@@ -15,7 +15,7 @@ feature "Order notification", :js do
     click_on "Cancel"
     page.driver.browser.switch_to.alert.accept
     expect(current_path).to eq("/admin/orders/#{order.number}/edit")
-    expect(SpreeMailchimpEcommerce::UpdateOrderJob).to have_been_enqueued.exactly(:once)
+    expect(SpreeMailchimpEcommerce::UpsertOrderJob).to have_been_enqueued.exactly(:once)
   end
 
   scenario "Ship order" do
@@ -26,7 +26,7 @@ feature "Order notification", :js do
     click_on "Ship"
     sleep(3)
     expect(current_path).to eq("/admin/orders/#{order.number}/edit")
-    expect(SpreeMailchimpEcommerce::UpdateOrderJob).to have_been_enqueued.exactly(:once)
+    expect(SpreeMailchimpEcommerce::UpsertOrderJob).to have_been_enqueued.exactly(:once)
   end
 
   scenario "Refund by reimbursement" do
@@ -42,7 +42,7 @@ feature "Order notification", :js do
     expect(current_path).to eq("/admin/orders/#{order.number}/customer_returns/1/edit")
     find(".action-edit").click
     click_on "Reimburse"
-    expect(SpreeMailchimpEcommerce::UpdateOrderJob).to have_been_enqueued.exactly(:once)
+    expect(SpreeMailchimpEcommerce::UpsertOrderJob).to have_been_enqueued.exactly(:once)
   end
 
   scenario "Refund payment" do
@@ -58,6 +58,6 @@ feature "Order notification", :js do
     expect(current_path).to eq("/admin/orders/#{order.number}/payments/#{payment.number}/refunds/new")
     select refund_reason.name.to_s, from: "refund_refund_reason_id"
     click_on "Refund"
-    expect(SpreeMailchimpEcommerce::UpdateOrderJob).to have_been_enqueued.exactly(:once)
+    expect(SpreeMailchimpEcommerce::UpsertOrderJob).to have_been_enqueued.exactly(:once)
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -76,7 +76,7 @@ describe Spree::Order, type: :model do
       order = create(:completed_order_with_totals)
       order.cancel
 
-      expect(SpreeMailchimpEcommerce::UpdateOrderJob).to have_been_enqueued.with(order.mailchimp_order)
+      expect(SpreeMailchimpEcommerce::UpsertOrderJob).to have_been_enqueued.with(order.mailchimp_order)
       expect(order.mailchimp_order["financial_status"]).to eq("cancelled")
     end
 
@@ -84,7 +84,7 @@ describe Spree::Order, type: :model do
       order = create(:order_ready_to_ship)
       order.shipments.first.ship!
 
-      expect(SpreeMailchimpEcommerce::UpdateOrderJob).to have_been_enqueued.with(order.mailchimp_order)
+      expect(SpreeMailchimpEcommerce::UpsertOrderJob).to have_been_enqueued.with(order.mailchimp_order)
       expect(order.mailchimp_order["fulfillment_status"]).to eq("shipped")
     end
 
@@ -92,7 +92,7 @@ describe Spree::Order, type: :model do
       order = create(:shipped_order)
       create(:refund, payment: order.payments.first)
 
-      expect(SpreeMailchimpEcommerce::UpdateOrderJob).to have_been_enqueued.with(order.mailchimp_order)
+      expect(SpreeMailchimpEcommerce::UpsertOrderJob).to have_been_enqueued.with(order.mailchimp_order)
       expect(order.mailchimp_order["financial_status"]).to eq("refunded")
     end
   end


### PR DESCRIPTION
I've noticed a large number of my update order jobs failing to complete
because the order did not previously exist in mailchimp.  While I would
love to debug this further (i.e. better understand *why* these orders
weren't there in the first place), a simple fix would be to use
`#upsert` instead of `#update` to get the orders into mailchimp.