### PR TITLE
Add a guard to `#update_mailchimp_cart`

### DIFF
--- a/app/models/spree_mailchimp_ecommerce/spree/order_decorator.rb
+++ b/app/models/spree_mailchimp_ecommerce/spree/order_decorator.rb
@@ -22,6 +22,8 @@ module SpreeMailchimpEcommerce
       end
 
       def update_mailchimp_cart
+        return unless mailchimp_cart_created
+
         ::SpreeMailchimpEcommerce::UpdateOrderCartJob.perform_later(mailchimp_cart)
       end
 


### PR DESCRIPTION
When a non-logged-in user updates the quantity of an item in their cart,
`update_mailchimp_cart` is called (by the `after_update` callback on
`SpreeMailchimpEcommerce::Spree::LineItemDecorator`) but the cart does
not yet have a user, so instead `update_mailchimp_cart` is called with a
mailchimp_cart that only has a `checkout_url` because the
`SpreeMailchimpEcommerce::OrderMethods#order_json` returns {} since
there is no user.