### PR TITLE
manually do an upsert

### DIFF
--- a/app/jobs/spree_mailchimp_ecommerce/upsert_order_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/upsert_order_job.rb
@@ -3,7 +3,14 @@
 module SpreeMailchimpEcommerce
   class UpsertOrderJob < ApplicationJob
     def perform(mailchimp_order)
-      gibbon_store.orders(mailchimp_order["id"]).upsert(body: mailchimp_order)
+      gibbon_store.orders(mailchimp_order["id"]).update(body: mailchimp_order)
+    rescue Gibbon::MailChimpError => e
+      if e.status_code == 404
+        gibbon_store.orders(mailchimp_order["id"]).create(body: mailchimp_order)
+      else
+        # re-raise
+        raise
+      end
     end
   end
 end


### PR DESCRIPTION
It turns out that mailchimp doesn't support upsert for the order records (only customers).  Do a manually create if an update fails with 404 (not found)