### PR TITLE
fix callbacks for user updates

### DIFF
--- a/app/jobs/spree_mailchimp_ecommerce/update_user_job.rb
+++ b/app/jobs/spree_mailchimp_ecommerce/update_user_job.rb
@@ -6,6 +6,12 @@ module SpreeMailchimpEcommerce
       return unless mailchimp_user
 
       gibbon_store.customers(mailchimp_user["id"]).update(body: mailchimp_user)
+    rescue Gibbon::MailChimpError => e
+      if e.status_code == 404
+        gibbon_store.customers.create(body: mailchimp_user)
+      else
+        Rails.logger.error("[MAILCHIMP] Error while creating user: #{e}")
+      end
     end
   end
 end

--- a/app/models/spree_mailchimp_ecommerce/spree/address_decorator.rb
+++ b/app/models/spree_mailchimp_ecommerce/spree/address_decorator.rb
@@ -1,0 +1,22 @@
+module SpreeMailchimpEcommerce
+  module Spree
+    module AddressDecorator
+      MAILCHIMP_ATTRIBUTES = ['firstname', 'lastname', 'address1', 'address2', 'city', 'state_id', 'zipcode', 'country_id'].freeze
+
+      def self.prepended(base)
+        base.after_update :update_mailchimp_user
+      end
+
+      private
+
+      def update_mailchimp_user
+        return if user&.bill_address_id != id
+        return if (previous_changes.keys & MAILCHIMP_ATTRIBUTES).empty?
+
+        SpreeMailchimpEcommerce::UpdateUserJob.perform_later(user.mailchimp_user)
+      end
+    end
+  end
+end
+
+Spree::Address.prepend(SpreeMailchimpEcommerce::Spree::AddressDecorator)

--- a/app/models/spree_mailchimp_ecommerce/spree/user_decorator.rb
+++ b/app/models/spree_mailchimp_ecommerce/spree/user_decorator.rb
@@ -1,6 +1,8 @@
 module SpreeMailchimpEcommerce
   module Spree
     module UserDecorator
+      MAILCHIMP_ATTRIBUTES = ['firstname', 'lastname', 'email', 'bill_address_id'].freeze
+
       def self.prepended(base)
         base.after_create :create_mailchimp_user
         base.after_update :update_mailchimp_user
@@ -21,8 +23,7 @@ module SpreeMailchimpEcommerce
       end
 
       def update_mailchimp_user
-        ignored_keys = %w[sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip updated_at]
-        return true if (previous_changes.keys - ignored_keys).empty?
+        return if (previous_changes.keys & MAILCHIMP_ATTRIBUTES).empty?
 
         ::SpreeMailchimpEcommerce::UpdateUserJob.perform_later(mailchimp_user)
       end

--- a/app/presenters/spree_mailchimp_ecommerce/user_mailchimp_presenter.rb
+++ b/app/presenters/spree_mailchimp_ecommerce/user_mailchimp_presenter.rb
@@ -11,7 +11,7 @@ module SpreeMailchimpEcommerce
     def json
       {
         id: Digest::MD5.hexdigest(user.email.downcase),
-        email_address: user.email || "",
+        email_address: user.email || '',
         opt_in_status: false,
         first_name: firstname,
         last_name: lastname,
@@ -21,11 +21,11 @@ module SpreeMailchimpEcommerce
     private
 
     def firstname
-      user.try(:firstname) || user&.bill_address&.firstname || "unknown firstname"
+      user.try(:firstname) || user.try(:first_name) || user&.bill_address&.firstname || 'unknown firstname'
     end
 
     def lastname
-      user.try(:lastname) || user&.bill_address&.lastname || "unknown lastname"
+      user.try(:lastname) || user.try(:last_name) || user&.bill_address&.lastname || 'unknown lastname'
     end
 
     def address

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+describe Spree::Address, type: :model do
+  describe 'after update' do
+    context 'when address is user bill address' do
+      shared_examples 'SpreeMailchimpEcommerce::UpdateUserJob enqueued' do
+        it 'enqueues SpreeMailchimpEcommerce::UpdateUserJob' do
+          expect(::SpreeMailchimpEcommerce::UpdateUserJob).to have_been_enqueued.with(user.reload.mailchimp_user)
+        end
+      end
+
+      let!(:address) { create(:address) }
+      let!(:user) { create(:user, bill_address: address) }
+
+      before { address.update(user: user) }
+
+      context 'when some of MAILCHIMP_ATTRIBUTES is updated' do
+        context 'when firstname attribute is updated' do
+          before { address.update(firstname: FFaker::Name.first_name) }
+
+          it_behaves_like 'SpreeMailchimpEcommerce::UpdateUserJob enqueued'
+        end
+
+        context 'when lastname attribute is updated' do
+          before { address.update(lastname: FFaker::Name.last_name) }
+
+          it_behaves_like 'SpreeMailchimpEcommerce::UpdateUserJob enqueued'
+        end
+      end
+
+      context 'when some other attribute is updated' do
+        it 'does not enqueue SpreeMailchimpEcommerce::UpdateUserJob' do
+          expect { address.update(phone: FFaker::PhoneNumber.short_phone_number) }.not_to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size)
+        end
+      end
+    end
+
+    context 'when address is not user bill address' do
+      shared_examples 'SpreeMailchimpEcommerce::UpdateUserJob not enqueued' do
+        it 'does not enqueue SpreeMailchimpEcommerce::UpdateUserJob' do
+          expect(::SpreeMailchimpEcommerce::UpdateUserJob).not_to have_been_enqueued
+        end
+      end
+
+      let!(:address) { create(:address, user: nil) }
+
+      context 'when firstname attribute is updated' do
+        before { address.update(firstname: FFaker::Name.first_name) }
+
+        it_behaves_like 'SpreeMailchimpEcommerce::UpdateUserJob not enqueued'
+      end
+
+      context 'when lastname attribute is updated' do
+        before { address.update(lastname: FFaker::Name.last_name) }
+
+        it_behaves_like 'SpreeMailchimpEcommerce::UpdateUserJob not enqueued'
+      end
+
+      context 'when some other attribute is updated' do
+        before { address.update(city: FFaker::Address.city) }
+
+        it_behaves_like 'SpreeMailchimpEcommerce::UpdateUserJob not enqueued'
+      end
+    end
+  end
+end

--- a/spec/presenters/user_mailchimp_presenter_spec.rb
+++ b/spec/presenters/user_mailchimp_presenter_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe SpreeMailchimpEcommerce::UserMailchimpPresenter, type: :presenter do
+  let(:address) { create(:address) }
+  let!(:user) { create(:user, bill_address: address) }
+
+  describe '.json' do
+    subject { described_class.new(user).json }
+
+    let(:result) do
+      {
+        id: Digest::MD5.hexdigest(user.email.downcase),
+        email_address: user.email,
+        opt_in_status: false,
+        first_name: address.firstname,
+        last_name: address.lastname,
+        address: {
+          address1: address.address1,
+          address2: address.address2,
+          city: address.city,
+          province: address.state&.name,
+          province_code: address.state&.abbr,
+          postal_code: address.zipcode,
+          country: address.country&.name,
+          country_code: address.country&.iso
+        }
+      }.as_json
+    end
+
+    it 'returns serialized object' do
+      expect(subject).to eq(result)
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes updating user. Most of user data which is sent to mailchimp comes from his bill address, due to that user update request should be sent also when his bill address is updated.

This PR also reduces amount of requests to mailchimp when user is updated. User update request will be sent only when one of attributes which is sent to mailchimp is changed (see User Presenter).

Also, this PR fixes updating user email. The issue is that we create mailchimp user id based on his email ([here](https://github.com/spree-contrib/spree_mailchimp_ecommerce/blob/master/app/presenters/spree_mailchimp_ecommerce/user_mailchimp_presenter.rb#L13)). So when user email is changed, his uniqe id also changes and `spree_mailchimp_ecommerce` is unable to find the existing user in mailchimp. I created a solution for that in `app/jobs/spree_mailchimp_ecommerce/update_user_job.rb`.
I could fix a way of creating mailchimp user id, but then existing mailchimp databases would have duplicated users.